### PR TITLE
Adding support for versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,9 @@ image-spec:
   name: Image Spec
   group: Open Containers Initiative (OCI)
   github_repo: opencontainers/image-spec
-  github_branch: master
+  default_version: v1.0.1
+  versions:
+    - v1.0.1
 
   # Courtesy list of pages relative to site root to link
   pages:
@@ -71,7 +73,9 @@ image-spec:
 The various urls are used to define relative paths in the repository. The list
 of pages (optional) will render a left side navigation to give the reader
 context of all the documents included for a spec. Importantly, the key `image-spec`
-at the top is used to lookup this metadata.
+at the top is used to lookup this metadata. Finally, the list of versions should
+correspond to releases. If a release isn't given in the browser as a variable,
+then we fall back to the `default_version` variable.
 
 ##### 2. Document Index Page
 

--- a/_data/specs.yaml
+++ b/_data/specs.yaml
@@ -3,7 +3,9 @@ image-spec:
   name: Image Spec
   group: Open Containers Initiative (OCI)
   github_repo: opencontainers/image-spec
-  github_branch: master
+  default_version: v1.0.1
+  versions:
+    - v1.0.1
 
   # Courtesy list of pages relative to site root to link
   pages:
@@ -24,7 +26,10 @@ distribution-spec:
   name: Distribution Spec
   group: Open Containers Initiative (OCI)
   github_repo: opencontainers/distribution-spec
-  github_branch: master
+  default_version: v1.0.0
+  versions:
+    - v1.0.0
+
   pages:
    - distribution-spec/
    - distribution-spec/conformance/README/
@@ -35,7 +40,10 @@ runtime-spec:
   name: Runtime Spec
   group: Open Containers Initiative (OCI)
   github_repo: opencontainers/runtime-spec
-  github_branch: master
+  default_version: v1.0.2
+  versions:
+   - v1.0.2
+
   pages:
    - runtime-spec/
    - runtime-spec/bundle/

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -8,8 +8,7 @@ layout: default
 
 <div id="content" style="display:none"></div>
 
-
-<p style="padding-top:30px">This content is served from <a href="https://github.com/{{ site.data.specs[page.key].github_repo }}/blob/{{ site.data.specs[page.key].github_branch }}/{{ page.spec }}" target="_blank">{{ site.data.specs[page.key].github_repo }}</a> on GitHub. You can
+<p style="padding-top:30px">This content is served from <a id="from_url" href="https://github.com/{{ site.data.specs[page.key].github_repo }}/blob/{{ site.data.specs[page.key].default_version }}/{{ page.spec }}" target="_blank">{{ site.data.specs[page.key].github_repo }}</a> on GitHub. You can
 make contributions or suggestions for changes there.
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.4/jquery.min.js"></script>
@@ -51,7 +50,23 @@ function slugify(text) {
         ;
 }
 
+function getParameterByName(name, url = window.location.href) {
+    name = name.replace(/[\[\]]/g, '\\$&');
+    var regex = new RegExp('[?&]' + name + '(=([^&#]*)|&|#|$)'),
+        results = regex.exec(url);
+    if (!results) return null;
+    if (!results[2]) return '';
+    return decodeURIComponent(results[2].replace(/\+/g, ' '));
+}
+
 $(document).ready(function(){
+
+    // Version (GitHub reference) comes from the url
+    window.version = getParameterByName('v') || "{{ site.data.specs[page.key].default_version }}";
+
+    // Serving content from this url
+    var from_url = "https://github.com/{{ site.data.specs[page.key].github_repo }}/blob/" + window.version + "/{{ page.spec }}"
+    $("#from_url").attr("href", from_url);
 
     // Get GitHub stars and forks for the repo
     var url = "https://api.github.com/search/repositories?q={{ site.data.specs[page.key].github_repo }}";
@@ -67,7 +82,7 @@ $(document).ready(function(){
        $('#forks').text(forks)
     });
 
-    url = "https://raw.githubusercontent.com/{{ site.data.specs[page.key].github_repo }}/{{ site.data.specs[page.key].github_branch }}/{{ page.spec }}"
+    url = "https://raw.githubusercontent.com/{{ site.data.specs[page.key].github_repo }}/" + window.version +  "/{{ page.spec }}"
     $.get(url, function(data) {
         var converter = new showdown.Converter({tables: true}),
                  html = converter.makeHtml(data);
@@ -90,7 +105,7 @@ $(document).ready(function(){
         for (var i = 0; i < images.length; i++) {
             image = images[i];
             if (!image.startsWith("http")) {
-                html = html.replace(image, "https://raw.githubusercontent.com/{{ site.data.specs[page.key].github_repo }}/{{ site.data.specs[page.key].github_branch}}/" + image);
+                html = html.replace(image, "https://raw.githubusercontent.com/{{ site.data.specs[page.key].github_repo }}/" + window.version + "/" + image);
             }            
         }
                 

--- a/pages/index.md
+++ b/pages/index.md
@@ -91,7 +91,6 @@ body {
   background-color: #fff;
   box-shadow: 0 5px 10px rgba(0, 0, 0, 0.1);
   transition: 0.15s ease;
-  cursor: pointer;
   position: relative;
 }
 .checkbox-tile:before {
@@ -134,13 +133,15 @@ body {
 <fieldset class="checkbox-group" style="border:none">
   <legend class="checkbox-group-legend">OpenContainers Specifications</legend>
   {% for spec in site.data.specs %}
-  <div class="checkbox clickme" data-id="{{ spec[0] }}" id="spec-{{ spec[0] }}">
+  <div class="checkbox" id="spec-{{ spec[0] }}">
     <label class="checkbox-wrapper">
       <input type="checkbox" class="checkbox-input" />
       <span class="checkbox-tile">
         <span class="checkbox-icon">
         </span>
         <span class="checkbox-label">{{ spec[1].name }}</span>
+        {% for version in spec[1].versions %}
+         <a class="clickme" href="#" data-id="{{ spec[0] }}" version-id="{{ version }}">{{ version }}</a>{% endfor %}
       </span>
     </label>
   </div>
@@ -154,6 +155,7 @@ body {
 
 <script>
 $(".clickme").click(function(){
-    document.location = "{{ site.baseurl }}/" + $(this).attr("data-id");
+    var url = $(this).attr("data-id") + "?v=" + $(this).attr('version-id'); 
+    document.location = "{{ site.baseurl }}/" + url;
 })
 </script>


### PR DESCRIPTION
This PR adds a lists of versions to the specs metadata, and for each one, the version string is rendered on the index page for the user to choose. Selecting a version (a GitHub release that can be referenced in the URL to see the file at that tag) will render that version, and not selecting a release (e.g., deleting the url parameter) will just render the default version. This means we are removing the github_branch variable, and replacing with default_version (expected to be latest) and versions.

Signed-off-by: vsoch <vsoch@users.noreply.github.com>